### PR TITLE
Also recognize application/x-multi-part-ldraw as a valid MIME

### DIFF
--- a/QT/desktop/ldview.desktop
+++ b/QT/desktop/ldview.desktop
@@ -7,5 +7,5 @@ Exec=LDView %f -platform xcb
 Icon=gnome-ldraw
 Terminal=false
 Type=Application
-MimeType=application/x-ldraw;application/x-multipart-ldraw;
+MimeType=application/x-ldraw;application/x-multipart-ldraw;application/x-multi-part-ldraw;
 Categories=Graphics;3DGraphics;Viewer;

--- a/QT/kde/ldviewthumbnailcreator.desktop
+++ b/QT/kde/ldviewthumbnailcreator.desktop
@@ -3,7 +3,7 @@ Encoding=UTF-8
 Type=Service
 Name=LDView
 X-KDE-ServiceTypes=ThumbCreator
-MimeType=application/x-ldraw;application/x-multipart-ldraw
+MimeType=application/x-ldraw;application/x-multipart-ldraw;application/x-multi-part-ldraw
 CacheThumbnail=true
 X-KDE-Library=ldviewthumbnail
 


### PR DESCRIPTION
Some applications use a different mime type for ldr files, and there is conflicting info about which one is the right one.

This change allow opening the other mime type with LDView.