### PR TITLE
Added metainfo (AppStream) file, and install it

### DIFF
--- a/QT/LDView.pro
+++ b/QT/LDView.pro
@@ -205,6 +205,8 @@ unix:!macx {
   script.extra     = $(INSTALL_PROGRAM) desktop/ldraw-thumbnailer $(INSTALL_ROOT)$${BINDIR}
   man.path         = $${MANDIR}/man1
   man.extra        = $(INSTALL_FILE) LDView.1 desktop/ldraw-thumbnailer.1 $(INSTALL_ROOT)$${MANDIR}/man1 ; $(COMPRESS) $(INSTALL_ROOT)$${MANDIR}/man1/*.1
+  metainfo.path    = $${DATADIR}/metainfo
+  metainfo.files   = desktop/io.github.tcobbs.LDView.metainfo.xml
   mimeinfo.path    = $${DATADIR}/mime-info
   mimeinfo.files   = desktop/ldraw.mime desktop/ldraw.keys
   mimepack.path    = $${DATADIR}/mime/packages
@@ -225,7 +227,7 @@ unix:!macx {
   icon4.extra      = $(INSTALL_FILE) images/LDViewIcon128.png $(INSTALL_ROOT)$${DATADIR}/pixmaps/ldview.png
   kdeserv.path     = $${KDESERVICES}
   kdeserv.files    = $${DESKTOPFILE}
-  INSTALLS += documentation target man mimeinfo mimepack appreg \
+  INSTALLS += documentation target man metainfo mimeinfo mimepack appreg \
               apps thumbnailer icon1 icon2 icon3 icon4 script kdeserv
   LIBS += -L../TCFoundation -L../LDLib -L../LDLoader -L../TRE -L../boost/lib \
           -lLDraw$$POSTFIX -L../LDExporter -lX11

--- a/QT/LDView.spec
+++ b/QT/LDView.spec
@@ -443,6 +443,7 @@ fi
 %{_datadir}/mime-info/ldraw.keys
 %{_datadir}/application-registry/ldview.applications
 %{_datadir}/applications/ldview.desktop
+%{_datadir}/metainfo/io.github.tcobbs.LDView.metainfo.xml
 %{_datadir}/thumbnailers/ldview.thumbnailer
 %{_bindir}/ldraw-thumbnailer
 %{_datadir}/pixmaps/gnome-ldraw.png

--- a/QT/desktop.sh
+++ b/QT/desktop.sh
@@ -4,6 +4,7 @@ cp -f desktop/ldraw.xml           /usr/share/mime/packages/
 cp -f desktop/ldraw.keys          /usr/share/mime-info/
 cp -f desktop/ldview.applications /usr/share/application-registry/
 cp -f desktop/ldview.desktop      /usr/share/applications/
+cp -f desktop/io.github.tcobbs.LDView.metainfo.xml /usr/share/metainfo/
 cp -f desktop/ldraw-thumbnailer   /usr/bin/
 cp -f desktop/ldview.thumbnailer  /usr/share/thumbnailers/
 

--- a/QT/desktop/io.github.tcobbs.LDView.metainfo.xml
+++ b/QT/desktop/io.github.tcobbs.LDView.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2021 LDView Developers -->
+<component type="desktop">
+ <id>io.github.tcobbs.LDView</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-2.0</project_license>
+ <name>LDView</name>
+ <summary>LDraw model viewer</summary>
+ <description>
+   <p>LDView is a real-time 3D viewer for displaying LDraw models
+   using hardware-accellerated 3D graphics. For information on LDraw,
+   please visit www.ldraw.org, the centralized LDraw information
+   site.</p>
+   <p> The program can read LDraw LDR/DAT files as well as MPD
+   files. It then allows you to rotate the model around to any angle
+   with the mouse.</p>
+ </description>
+ <content_rating type="oars-1.1" />
+ <launchable type="desktop-id">ldview.desktop</launchable>
+ <translation type="qt">ldview</translation>
+ <screenshots>
+  <screenshot type="default">
+   <image>https://tcobbs.github.io/ldview/LDView.png</image>
+   <caption>The main LDview window</caption>
+  </screenshot>
+ </screenshots>
+ <update_contact>ldview_AT_gmail.com</update_contact>
+ <url type="homepage">https://tcobbs.github.io/ldview/</url>
+ <url type="bugtracker">https://github.com/tcobbs/ldview/issues</url>
+ <releases>
+   <release version="4.4.1" date="2022-02-11" />
+   <release version="4.4" date="2021-07-05" />
+   <release version="4.3" date="2018-01-30" />
+ </releases>
+</component>


### PR DESCRIPTION
AppStream files are part of XDG, and are required for Flatpak (see #55) and usefull in general.

This patch add the file, and install it.