### PR TITLE
Win: treat build error C3861: '_mkgmtime': identifier not found

### DIFF
--- a/TCFoundation/TCUnzip.cpp
+++ b/TCFoundation/TCUnzip.cpp
@@ -3,6 +3,7 @@
 
 #ifdef WIN32
 #include <io.h>
+#include <time.h>
 #if defined(_MSC_VER) && _MSC_VER >= 1400 && defined(_DEBUG)
 #define new DEBUG_CLIENTBLOCK
 #endif // _DEBUG


### PR DESCRIPTION
Hi Travis & Peter,

I encountered this Windows build break some weeks ago and noticed that when attempting to build a clean pull of LDView master, the break is still present.

![LDView_Build_C3861_Error](https://github.com/user-attachments/assets/c57f0f70-e8ea-4f61-b72f-aaf9c78dd00a)

Cheers,