### PR TITLE
Win: add minizip.vcxproj project reference to LDView.vcxproj

### DIFF
--- a/LDView.vcxproj
+++ b/LDView.vcxproj
@@ -534,6 +534,10 @@
       <Project>{a3a84737-5017-4577-b8a2-79429a25b8b6}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="3rdParty\minizip\minizip.vcxproj">
+      <Project>{a90c8bd0-bb72-4e5a-8c8d-2637966b0013}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="CUI\CUI.vcxproj">
       <Project>{37143396-d8f0-42bf-bdd9-bb9812f71814}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>


### PR DESCRIPTION
Hi Travis & Peter,

The minizip.vcxproj project reference is missing from LDView.vcxproj - it is only present in LDView.sln. 

To be consistent with gl2ps and timyxml, it seems reasonable to also add minizip.

Cheers,