### PR TITLE
bugfix: make LDView thumbnails work again on KDE Frameworks >= 5.100 (e.g. Dolphin on kubuntu24)

### DIFF
--- a/QT/kde5/CMakeLists.txt
+++ b/QT/kde5/CMakeLists.txt
@@ -1,20 +1,19 @@
 project(ldviewthumbnail)
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-set(QT_MIN_VERSION "5.2.0")
 
 find_package(ECM 1.0.0 REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(FeatureSummary)
-include(WriteBasicConfigVersionFile)
 include(KDEInstallDirs)
 include(KDECMakeSettings)
 include(KDECompilerSettings)
-find_package(KF5 REQUIRED COMPONENTS KIO)
-set(ldviewthumbnail_SRCS ldviewthumbnailcreator.cpp)
-add_library(ldviewthumbnail MODULE ${ldviewthumbnail_SRCS})
 
-target_link_libraries(ldviewthumbnail PRIVATE KF5::KIOWidgets )
-install(TARGETS ldviewthumbnail DESTINATION ${PLUGIN_INSTALL_DIR} )
-install(FILES  ldviewthumbnailcreator.desktop DESTINATION ${SERVICES_INSTALL_DIR})
+find_package(KF5 REQUIRED COMPONENTS KIO CoreAddons)
 
+kcoreaddons_add_plugin(ldviewthumbnail
+   SOURCES ldviewthumbnailcreator.cpp
+   INSTALL_NAMESPACE "kf5/thumbcreator"
+)
+
+target_link_libraries(ldviewthumbnail PRIVATE KF5::KIOGui KF5::CoreAddons)

--- a/QT/kde5/ldviewthumbnail.json
+++ b/QT/kde5/ldviewthumbnail.json
@@ -1,0 +1,10 @@
+{
+    "CacheThumbnail": true,
+    "KPlugin": {
+        "MimeTypes": [
+            "application/x-ldraw",
+            "application/x-multipart-ldraw"
+        ],
+        "Name": "LDView Models"
+    }
+}

--- a/QT/kde5/ldviewthumbnailcreator.cpp
+++ b/QT/kde5/ldviewthumbnailcreator.cpp
@@ -1,50 +1,44 @@
 #include "ldviewthumbnailcreator.h"
 #include <QTemporaryFile>
-#include <QTextStream>
+#include <QProcess>
+#include <QImage>
+#include <QFile>
+#include <KPluginFactory>
 
-extern "C"
+K_PLUGIN_CLASS_WITH_JSON(LDViewCreator, "ldviewthumbnail.json")
+
+LDViewCreator::LDViewCreator(QObject *parent, const QVariantList &args)
+    : KIO::ThumbnailCreator(parent, args)
 {
-   Q_DECL_EXPORT ThumbCreator *new_creator()
-   {
-     return new LDViewCreator;
-   }
-};
+}
 
-
-bool LDViewCreator::create (const QString &path, int w, int h, QImage &img)
+KIO::ThumbnailResult LDViewCreator::create (const KIO::ThumbnailRequest &request)
 {
 	QString tmpname;
-	bool result;
 	QTemporaryFile tmpfile;
-
-//	QFile outFile("/tmp/ldview.log");
-//	outFile.open(QIODevice::WriteOnly | QIODevice::Append);
-//	QTextStream textStream(&outFile);
-//	textStream <<  path << ":" << w << ":" << h <<"\n";
-//	outFile.close();
+	QImage img;
+	QString path = request.url().toLocalFile();
+	const int w = request.targetSize().width();
+	const int h = request.targetSize().height();
 
 	if (tmpfile.open())
 	{
-		tmpname=tmpfile.fileName();
+		tmpname = tmpfile.fileName();
 		tmpfile.close();
 		tmpfile.remove();
 	}
-	tmpname+=".png";
-	QProcess *process = new QProcess;
-	process->start("/usr/bin/LDView", 
-		QStringList() << path << "-SaveSnapshot="+tmpname << 
+	tmpname += ".png";
+	QProcess process;
+	process.start("/usr/bin/LDView",
+		QStringList() << path << "-SaveSnapshot="+tmpname <<
 		QString("-SaveWidth=")+QString::number(w) <<
 		QString("-SaveHeight=")+QString::number(h) <<
 		"-ShowErrors=0" << "-SaveActualSize=0");
-	if (!process->waitForFinished())
-		return false;
-	result = img.load(tmpname);
+	if (!process.waitForFinished())
+		return KIO::ThumbnailResult::fail();
+	img.load(tmpname);
 	QFile::remove (tmpname);
-	return result;
+	return KIO::ThumbnailResult::pass(img);
 }
 
-ThumbCreator::Flags LDViewCreator::flags() const
-{
-	return (Flags)(DrawFrame | BlendIcon);
-}
-
+#include "ldviewthumbnailcreator.moc"

--- a/QT/kde5/ldviewthumbnailcreator.desktop
+++ b/QT/kde5/ldviewthumbnailcreator.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Encoding=UTF-8
-Type=Service
-Name=LDView Models
-X-KDE-ServiceTypes=ThumbCreator
-MimeType=application/x-ldraw;application/x-multipart-ldraw;application/x-multi-part-ldraw
-CacheThumbnail=true
-X-KDE-Library=ldviewthumbnail
-

--- a/QT/kde5/ldviewthumbnailcreator.h
+++ b/QT/kde5/ldviewthumbnailcreator.h
@@ -1,13 +1,16 @@
-#include <kio/thumbcreator.h>
-#include <QProcess>
-#include <QImage>
-#include <QFile>
+#ifndef _LDVIEWTHUMBNAILCREATOR_H_
+#define _LDVIEWTHUMBNAILCREATOR_H_
+
+#include <KIO/ThumbnailCreator>
 #include <QObject>
 
-class LDViewCreator : public QObject, public ThumbCreator
+class LDViewCreator : public KIO::ThumbnailCreator
 {
 Q_OBJECT
 public:
-	virtual bool create (const QString &path, int, int, QImage &img);
-	virtual Flags flags() const;
+	LDViewCreator(QObject *parent, const QVariantList &args);
+	KIO::ThumbnailResult create (const KIO::ThumbnailRequest &request) override;
 };
+
+#endif // _LDVIEWTHUMBNAILCREATOR_H_
+


### PR DESCRIPTION
bugfix: make LDView thumbnails work again on KDE Frameworks >= 5.100 (e.g. Dolphin on kubuntu24)

Port the QT/kde5 thumbnailer from the legacy ThumbCreator API to the modern KIO::ThumbnailCreator API (same approach as QT/kde6). KIO >= 5.100 no longer loads legacy ThumbCreator plugins, so .ldr/.mpd/.dat files showed no thumbnails in Dolphin.

- build via kcoreaddons_add_plugin with INSTALL_NAMESPACE kf5/thumbcreator
- add embedded JSON metadata (ldviewthumbnail.json)
- remove obsolete .desktop service registration

Fixes #115
