### PR TITLE
bugfix: on Linux render thumbnails for LDRAW *.dat files containing Unofficial Parts

### DIFF
--- a/QT/desktop/ldraw.xml
+++ b/QT/desktop/ldraw.xml
@@ -23,6 +23,33 @@
         <match type="string" value="0\ !LDRAW_ORG\ Shortcut" offset="0:1000"/>
     </magic>
     <magic priority="60">
+        <match type="string" value="0\ !LDRAW_ORG\ Subpart" offset="0:1000"/>
+    </magic>
+    <magic priority="60">
+        <match type="string" value="0\ !LDRAW_ORG\ 8_Primitive" offset="0:1000"/>
+    </magic>
+    <magic priority="60">
+        <match type="string" value="0\ !LDRAW_ORG\ 48_Primitive" offset="0:1000"/>
+    </magic>
+    <magic priority="60">
+        <match type="string" value="0\ !LDRAW_ORG\ Unofficial_Part" offset="0:1000"/>
+    </magic>
+    <magic priority="60">
+        <match type="string" value="0\ !LDRAW_ORG\ Unofficial_Primitive" offset="0:1000"/>
+    </magic>
+    <magic priority="60">
+        <match type="string" value="0\ !LDRAW_ORG\ Unofficial_Shortcut" offset="0:1000"/>
+    </magic>
+    <magic priority="60">
+        <match type="string" value="0\ !LDRAW_ORG\ Unofficial_Subpart" offset="0:1000"/>
+    </magic>
+    <magic priority="60">
+        <match type="string" value="0\ !LDRAW_ORG\ Unofficial_8_Primitive" offset="0:1000"/>
+    </magic>
+    <magic priority="60">
+        <match type="string" value="0\ !LDRAW_ORG\ Unofficial_48_Primitive" offset="0:1000"/>
+    </magic>
+    <magic priority="60">
         <match type="string" value="0\ LDRAW_ORG\ Shortcut" offset="0:1000"/>
     </magic>
 


### PR DESCRIPTION
bugfix: on Linux render thumbnails for LDRAW *.dat files containing Unofficial Parts

Fixes #117