### PR TITLE
bugfix: fix concurrency bug: while loading a large model file, preferences loading could interfere and destroy the search path for files

### DIFF
--- a/LDLoader/LDLModel.cpp
+++ b/LDLoader/LDLModel.cpp
@@ -1053,39 +1053,49 @@ void LDLModel::setSystemLDrawDir(char* value)
 }
 
 // NOTE: static function.
-void LDLModel::setLDrawDir(const char *value)
+void LDLModel::setLDrawDir(const char* value)
 {
-	if (value != sm_systemLDrawDir || !value)
+	char* valueCleaned = cleanedUpPath(value);
+
+	// Compare by content, not by pointer: setSystemLDrawDir() stores its own
+	// copy, so the incoming pointer can never equal sm_systemLDrawDir even
+	// for an identical directory. Without this early-out every call tore
+	// down and re-read the LDraw ini, wiping the <MODELDIR> search dir that
+	// was added while a model was loading, so subparts/siblings went missing.
+	if (valueCleaned && sm_systemLDrawDir && strcmp(valueCleaned, sm_systemLDrawDir)==0)
 	{
-		delete[] sm_systemLDrawDir;
-		if (value)
+		delete[] valueCleaned;
+		return;
+	}
+
+	delete[] sm_systemLDrawDir;
+	if (valueCleaned)
+	{
+		setSystemLDrawDir(valueCleaned);
+	}
+	else
+	{
+		setSystemLDrawDir(NULL);
+	}
+	if (sm_lDrawIni)
+	{
+		LDrawIniFree(sm_lDrawIni);
+	}
+	sm_lDrawIni = LDrawIniGet(sm_systemLDrawDir, NULL, NULL);
+	if (sm_lDrawIni)
+	{
+		if (fileCaseCallback)
 		{
-			setSystemLDrawDir(cleanedUpPath(value));
+			LDrawIniSetFileCaseCallback(fileCaseCallback);
 		}
-		else
+		if (!sm_systemLDrawDir)
 		{
-			setSystemLDrawDir(NULL);
+			setSystemLDrawDir(copyString(sm_lDrawIni->LDrawDir));
 		}
-		if (sm_lDrawIni)
+		if (sm_systemLDrawDir)
 		{
-			LDrawIniFree(sm_lDrawIni);
-		}
-		sm_lDrawIni = LDrawIniGet(sm_systemLDrawDir, NULL, NULL);
-		if (sm_lDrawIni)
-		{
-			if (fileCaseCallback)
-			{
-				LDrawIniSetFileCaseCallback(fileCaseCallback);
-			}
-			if (!sm_systemLDrawDir)
-			{
-				setSystemLDrawDir(copyString(sm_lDrawIni->LDrawDir));
-			}
-			if (sm_systemLDrawDir)
-			{
-				stripTrailingPathSeparators(sm_systemLDrawDir);
-				LDrawIniComputeRealDirs(sm_lDrawIni, 1, 0, NULL);
-			}
+			stripTrailingPathSeparators(sm_systemLDrawDir);
+			LDrawIniComputeRealDirs(sm_lDrawIni, 1, 0, NULL);
 		}
 	}
 }

--- a/QT/ModelViewerWidget.cpp
+++ b/QT/ModelViewerWidget.cpp
@@ -459,7 +459,16 @@ void ModelViewerWidget::initializeGL(void)
 {
 	lock();
 	TREGLExtensions::setup();
-	preferences->doCancel();
+
+	// Only reload settings when no model is being loaded: doCancel() tears
+	// down and re-reads preferences, and during processEvents() a queued
+	// resize can re-enter initializeGL() mid-load, reloading settings over
+	// the in-progress model and breaking it.
+	if (!loading)
+	{
+		preferences->doCancel();
+	}
+
 	doViewStatusBar(preferences->getStatusBar());
 	doViewToolBar(preferences->getToolBar());
 	if (saving || printing)


### PR DESCRIPTION
bugfix: fix concurrency bug: while loading a large model file, preferences loading could interfere and destroy the search path for files

Root Cause:

The settings-loading path ran twice while a model was being loaded:

1. LDLModel::setLDrawDir() compared LDraw directories by pointer instead of by string. Since setSystemLDrawDir() stores its own copy, an identical directory reload was treated as a change, tearing down and re-reading the LDraw ini - which wiped the <MODELDIR> search dir added during the load. Subparts/sibling files then couldn't be found.

2. ModelViewerWidget::initializeGL() called preferences->doCancel() unconditionally. During processEvents(), a queued resize event could re-enter this method mid-load and reload settings over the in-progress model.

Fix:
* Compare the LDraw directory contents with strcmp() so an identical reload is a no-op, and
* only call doCancel() when no model is currently loading.

Fixes #113